### PR TITLE
Add Homebrew Installation Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,30 @@ Options:
 
 ## Installation
 
+### Using Cargo
+
 kdlfmt can be installed using Cargo, the package manager for Rust ([crates.io](https://crates.io/crates/kdlfmt)).
 
 ```shell
 cargo install kdlfmt
 ```
 
-If you do not have/want Rust installed on your device you can find precompiled binaries on the [release](https://github.com/hougesen/kdlfmt/releases) page.
+### Using Homebrew
+
+If you're on macOS or Linux, you can install kdlfmt using Homebrew:
+
+```shell
+# Tap and install
+brew tap hougesen/tap
+brew install kdlfmt
+
+# Or install directly in one command
+brew install hougesen/tap/kdlfmt
+```
+
+### Precompiled Binaries
+
+If you do not have/want Rust or Homebrew installed on your device, you can find precompiled binaries on the [release](https://github.com/hougesen/kdlfmt/releases) page.
 
 ## Usage
 


### PR DESCRIPTION
I initially missed the home-brew install and thought the only install method was through cargo. I later found that you did have a tap for `kdlfmt` so I thought I'd add that in the docs so others can see it straight from the README. I think the release page is not the first place I'd go to find install commands. I feel that it would be better just to detail this on the repos README.
