### PR TITLE
build: custom gh runner for x86_64-unknown-linux-musl & aarch64-unknown-linux-gnu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Dates are d
 
 #### [Unreleased](https://github.com/hougesen/kdlfmt/compare/v0.0.16...HEAD)
 
+- build: custom gh runner for x86_64-unknown-linux-musl & aarch64-unknown-linux-gnu [`#115`](https://github.com/hougesen/kdlfmt/pull/115)
+- docs: add Homebrew installation instructions [`#114`](https://github.com/hougesen/kdlfmt/pull/114)
+
 #### [v0.0.16](https://github.com/hougesen/kdlfmt/compare/v0.0.15...v0.0.16)
 
 > 5 May 2025

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -55,10 +55,7 @@ impl KdlFmtConfig {
                 .get_arg(Self::indent_size_key())
                 .and_then(kdl::KdlValue::as_integer)
             {
-                config.indent = Self::get_indent(
-                    indent_size.max(0).min(usize::MAX as i128) as usize,
-                    config.use_tabs,
-                );
+                config.indent = Self::get_indent(indent_size.max(0) as usize, config.use_tabs);
                 config.from_kdlfmt_file = true;
             }
         }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,5 +27,13 @@ npm-package = "kdlfmt"
 global = "ubuntu-latest"
 
 # https://github.com/axodotdev/cargo-dist/issues/1760
+[dist.github-custom-runners.aarch64-unknown-linux-gnu]
+runner = "ubuntu-latest"
+
+# https://github.com/axodotdev/cargo-dist/issues/1760
 [dist.github-custom-runners.x86_64-unknown-linux-gnu]
+runner = "ubuntu-latest"
+
+# https://github.com/axodotdev/cargo-dist/issues/1760
+[dist.github-custom-runners.x86_64-unknown-linux-musl]
 runner = "ubuntu-latest"


### PR DESCRIPTION
Set the github workflow runner to `ubuntu-latest` since cargo-dist has not yet been patched (https://github.com/axodotdev/cargo-dist/issues/1760).
